### PR TITLE
feat(mlcache) custom LRU layers

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -16,6 +16,7 @@ local error        = error
 local shared       = ngx.shared
 local tostring     = tostring
 local tonumber     = tonumber
+local insert       = table.insert
 local setmetatable = setmetatable
 
 
@@ -149,12 +150,13 @@ function _M.new(shm, opts)
         return nil, "no such lua_shared_dict: " .. shm
     end
 
-    local self  = {
-        lru     = lrucache.new(opts.lru_size or 100),
-        dict    = dict,
-        shm     = shm,
-        ttl     = opts.ttl     or 30,
-        neg_ttl = opts.neg_ttl or 5
+    local self     = {
+        lru        = lrucache.new(opts.lru_size or 100), -- default lru
+        lrus       = {},
+        dict       = dict,
+        shm        = shm,
+        ttl        = opts.ttl     or 30,
+        neg_ttl    = opts.neg_ttl or 5,
     }
 
     if opts.ipc_shm then
@@ -170,6 +172,10 @@ function _M.new(shm, opts)
 
         self.ipc:subscribe(self.ipc_invalidation_channel, function(key)
             self.lru:delete(key)
+
+            for i = 1, #self.lrus do
+                self.lrus[i]:delete(key)
+            end
         end)
     end
 
@@ -177,18 +183,37 @@ function _M.new(shm, opts)
 end
 
 
-local function set_lru(self, key, value, ttl)
+function _M:add_lru(name, lru)
+    if type(name) ~= "string" or #name == 0 then
+        return error("name must be a non-empty string")
+    end
+
+    if type(lru) ~= "table" then
+        return error("lru appears not to be a lua-resty-lrucache instance")
+    end
+
+    if self.lrus[name] then
+        return error("an lru named '" .. name .. "' has already been added")
+    end
+
+    self.lrus[name] = lru
+
+    insert(self.lrus, lru)
+end
+
+
+local function set_lru(lru, key, value, ttl)
     if ttl == 0 then
         ttl = huge
     end
 
-    self.lru:set(key, value, ttl)
+    lru:set(key, value, ttl)
 
     return value
 end
 
 
-local function shmlru_get(self, key)
+local function shmlru_get(self, lru, key)
     local v, err = self.dict:get(key)
     if err then
         return nil, "could not read from lua_shared_dict: " .. err
@@ -201,7 +226,7 @@ local function shmlru_get(self, key)
 
         -- value_type of 0 is a nil entry
         if value_type == 0 then
-            return set_lru(self, key, CACHE_MISS_SENTINEL_LRU, remaining_ttl)
+            return set_lru(lru, key, CACHE_MISS_SENTINEL_LRU, remaining_ttl)
         end
 
         local value, err = unmarshallers[value_type](str_serialized)
@@ -210,12 +235,12 @@ local function shmlru_get(self, key)
                         "retrieval: " .. err
         end
 
-        return set_lru(self, key, value, remaining_ttl)
+        return set_lru(lru, key, value, remaining_ttl)
     end
 end
 
 
-local function shmlru_set(self, key, value, ttl, neg_ttl)
+local function shmlru_set(self, lru, key, value, ttl, neg_ttl)
     local at = now()
 
     if value == nil then
@@ -230,7 +255,7 @@ local function shmlru_set(self, key, value, ttl, neg_ttl)
 
         -- set our own worker's LRU cache
 
-        set_lru(self, key, CACHE_MISS_SENTINEL_LRU, neg_ttl)
+        set_lru(lru, key, CACHE_MISS_SENTINEL_LRU, neg_ttl)
 
         return nil
     end
@@ -261,7 +286,7 @@ local function shmlru_set(self, key, value, ttl, neg_ttl)
 
     -- set our own worker's LRU cache
 
-    return set_lru(self, key, value, ttl)
+    return set_lru(lru, key, value, ttl)
 end
 
 
@@ -286,6 +311,7 @@ function _M:get(key, opts, cb, ...)
 
     -- opts validation
 
+    local lru
     local ttl
     local neg_ttl
 
@@ -314,8 +340,24 @@ function _M:get(key, opts, cb, ...)
             end
         end
 
+        if opts.lru ~= nil then
+            if type(opts.lru) ~= "string" or #opts.lru == 0 then
+                return error("opts.lru must be a non-empty string")
+            end
+
+            lru = self.lrus[opts.lru]
+
+            if not lru then
+                return error("no lru named '" .. opts.lru .. "'")
+            end
+        end
+
         ttl     = opts.ttl
         neg_ttl = opts.neg_ttl
+    end
+
+    if not lru then
+        lru = self.lru
     end
 
     if not ttl then
@@ -328,7 +370,7 @@ function _M:get(key, opts, cb, ...)
 
     -- worker LRU cache retrieval
 
-    local data = self.lru:get(key)
+    local data = lru:get(key)
     if data == CACHE_MISS_SENTINEL_LRU then
         return nil
     end
@@ -340,7 +382,7 @@ function _M:get(key, opts, cb, ...)
     -- not in worker's LRU cache, need shm lookup
 
     local err
-    data, err = shmlru_get(self, key)
+    data, err = shmlru_get(self, lru, key)
     if err then
         return nil, err
     end
@@ -368,7 +410,7 @@ function _M:get(key, opts, cb, ...)
 
     -- check for another worker's success at running the callback
 
-    data, err = shmlru_get(self, key)
+    data, err = shmlru_get(self, lru, key)
     if err then
         return unlock_and_ret(lock, nil, err)
     end
@@ -388,7 +430,7 @@ function _M:get(key, opts, cb, ...)
         return unlock_and_ret(lock, nil, "callback threw an error: " .. err)
     end
 
-    local value, err = shmlru_set(self, key, err, ttl, neg_ttl)
+    local value, err = shmlru_set(self, lru, key, err, ttl, neg_ttl)
     if err then
         return unlock_and_ret(lock, nil, err)
     end
@@ -438,6 +480,10 @@ function _M:delete(key)
     end
 
     self.lru:delete(key)
+
+    for i = 1, #self.lrus do
+        self.lrus[i]:delete(key)
+    end
 
     local ok, err = self.dict:delete(key)
     if not ok then

--- a/t/07-custom-lrus.t
+++ b/t/07-custom-lrus.t
@@ -1,0 +1,337 @@
+#vim:set ts=4 sts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+workers(2);
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict  cache 1m;
+    lua_shared_dict  events 1m;
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: add_lru() validates args
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("cache")
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local ok, err = pcall(cache.add_lru, cache)
+            if not ok then
+                ngx.say(err)
+            end
+
+            local ok, err = pcall(cache.add_lru, cache, "")
+            if not ok then
+                ngx.say(err)
+            end
+
+            local ok, err = pcall(cache.add_lru, cache, "my_lru", false)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+name must be a non-empty string
+name must be a non-empty string
+lru appears not to be a lua-resty-lrucache instance
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: add_lru() prevents overriding an already added lru
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("cache")
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local lrucache = require "resty.lrucache"
+
+            local lru = lrucache.new(100)
+
+            cache:add_lru("my_lru", lru)
+
+            local ok, err = pcall(cache.add_lru, cache, "my_lru", lru)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+an lru named 'my_lru' has already been added
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: get() validates opts.lru
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("cache")
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local function cb() end
+
+            local ok, err = pcall(cache.get, cache, "my_key", { lru = false }, cb)
+            if not ok then
+                ngx.say(err)
+            end
+
+            local ok, err = pcall(cache.get, cache, "my_key", { lru = "" }, cb)
+            if not ok then
+                ngx.say(err)
+            end
+
+            local ok, err = pcall(cache.get, cache, "my_key", { lru = "my_lru" }, cb)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+opts.lru must be a non-empty string
+opts.lru must be a non-empty string
+no lru named 'my_lru'
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: get() with custom lru avoids default lru
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+            local lrucache = require "resty.lrucache"
+
+            local lru = lrucache.new(100)
+
+            local cache, err = mlcache.new("cache")
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            cache:add_lru("my_lru", lru)
+
+            local function cb_number()
+                return 123
+            end
+
+            local function cb_nil()
+                return nil
+            end
+
+            local value, err = cache:get("my_key", { lru = "my_lru" }, cb_number)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say("custom lru has: ", lru:get("my_key"))
+            ngx.say("default lru has: ", cache.lru:get("my_key"))
+
+            local value, err = cache:get("my_nil_key", { lru = "my_lru" }, cb_nil)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say("custom lru has a nil sentinel: ", lru:get("my_nil_key") ~= nil)
+        }
+    }
+--- request
+GET /t
+--- response_body
+custom lru has: 123
+default lru has: nil
+custom lru has a nil sentinel: true
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: get() several lrus can store the same value
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+            local lrucache = require "resty.lrucache"
+
+            local lru = lrucache.new(100)
+
+            local cache, err = mlcache.new("cache")
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            cache:add_lru("my_lru", lru)
+
+            local function cb_number()
+                return 123
+            end
+
+            local value, err = cache:get("my_key", nil, cb_number)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local value, err = cache:get("my_key", { lru = "my_lru" }, cb_number)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say("custom lru has: ", lru:get("my_key"))
+            ngx.say("default lru has: ", cache.lru:get("my_key"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+custom lru has: 123
+default lru has: 123
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: get() works with pureffi lru implementation
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+            local lrucache = require "resty.lrucache.pureffi"
+
+            local lru = lrucache.new(100)
+
+            local cache, err = mlcache.new("cache")
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            cache:add_lru("my_pureffi_lru", lru)
+
+            local function cb()
+                return 123
+            end
+
+            local value, err = cache:get("my_key", { lru = "my_pureffi_lru" }, cb)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say("pureffi lru has: ", lru:get("my_key"))
+            ngx.say("default lru has: ", cache.lru:get("my_key"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+pureffi lru has: 123
+default lru has: nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: delete() invalidates from all lrus
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+            local lrucache = require "resty.lrucache"
+
+            local lru = lrucache.new(100)
+
+            local cache, err = mlcache.new("cache", { ipc_shm = "events" })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            cache:add_lru("my_lru", lru)
+
+            local function cb()
+                return 123
+            end
+
+            local value, err = cache:get("my_key", nil, cb)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say("default lru: ", cache.lru:get("my_key"))
+
+            local value, err = cache:get("my_key", { lru = "my_lru" }, cb)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say("custom lru: ", lru:get("my_key"))
+
+            assert(cache:delete("my_key"))
+
+            ngx.say("default lru: ", cache.lru:get("my_key"))
+            ngx.say("custom lru: ", lru:get("my_key"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+default lru: 123
+custom lru: 123
+default lru: nil
+custom lru: nil
+--- no_error_log
+[error]


### PR DESCRIPTION
We can now instruct mlcache to cache a given value in user-specified
LRU. One can now namespace entities, and store entities of various
sizes, hit/miss frequency in different Lua-land LRUs. One can also use
the `pureffi` LRU implementation if desired.

```lua
local resty_lru = require "resty.lrucache.pureffi"
local my_lru = resty_lru.new(10e3)

local cache = mlcache.new()

cache:add_lru("my_pureffi_lru", my_lru)

local value, err = cache:get("my_key", { lru = "my_pureffi_lru" }, cb)
if err then
    error(err)
end

-- value is stored in the custom lru
print(my_lru:get("my_key")) -- "123"
```