### PR TITLE
perf(mlcache) faster shm unmarshalling

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -65,14 +65,15 @@ local marshallers = {
 
 local unmarshallers = {
     shm_value = function(marshalled)
-        local sep_1 = find(marshalled, ":", 1        , true)
-        local sep_2 = find(marshalled, ":", sep_1 + 1, true)
-        local sep_3 = find(marshalled, ":", sep_2 + 1, true)
+        -- split our shm marshalled value by the hard-coded ":" tokens
+        -- "type:at:ttl:value"
+        -- 1:1501831735.052000:0.500000:123
+        local ttl_last = find(marshalled, ":", 21, true) - 1
 
-        local value_type = sub(marshalled, 1        , sep_1 - 1)
-        local at         = sub(marshalled, sep_1 + 1, sep_2 - 1)
-        local ttl        = sub(marshalled, sep_2 + 1, sep_3 - 1)
-        local str_value  = sub(marshalled, sep_3 + 1)
+        local value_type = sub(marshalled, 1, 1)         -- n:...
+        local at         = sub(marshalled, 3, 19)        -- n:1501831160
+        local ttl        = sub(marshalled, 21, ttl_last)
+        local str_value  = sub(marshalled, ttl_last + 2)
 
         return str_value, tonumber(value_type), tonumber(at), tonumber(ttl)
     end,


### PR DESCRIPTION
We now unmarshall values with hard-coded substring indexes thanks to our
encoding format.