### PR TITLE
feat(mlcache) get() returns level of hit cache

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -272,13 +272,13 @@ local function shmlru_set(self, key, value, ttl, neg_ttl)
 end
 
 
-local function unlock_and_ret(lock, res, err)
+local function unlock_and_ret(lock, res, err, hit_lvl)
     local ok, lerr = lock:unlock()
     if not ok then
         return nil, "could not unlock callback: " .. lerr
     end
 
-    return res, err
+    return res, err, hit_lvl
 end
 
 
@@ -337,11 +337,11 @@ function _M:get(key, opts, cb, ...)
 
     local data = self.lru:get(key)
     if data == CACHE_MISS_SENTINEL_LRU then
-        return nil
+        return nil, nil, 1
     end
 
     if data ~= nil then
-        return data
+        return data, nil, 1
     end
 
     -- not in worker's LRU cache, need shm lookup
@@ -353,11 +353,11 @@ function _M:get(key, opts, cb, ...)
     end
 
     if data == CACHE_MISS_SENTINEL_LRU then
-        return nil
+        return nil, nil, 2
     end
 
     if data ~= nil then
-        return data
+        return data, nil, 2
     end
 
     -- not in shm either
@@ -382,10 +382,10 @@ function _M:get(key, opts, cb, ...)
 
     if data then
         if data == CACHE_MISS_SENTINEL_LRU then
-            return unlock_and_ret(lock, nil)
+            return unlock_and_ret(lock, nil, nil, 2)
         end
 
-        return unlock_and_ret(lock, data)
+        return unlock_and_ret(lock, data, nil, 2)
     end
 
     -- still not in shm, we are responsible for running the callback
@@ -400,7 +400,7 @@ function _M:get(key, opts, cb, ...)
         return unlock_and_ret(lock, nil, err)
     end
 
-    return unlock_and_ret(lock, value)
+    return unlock_and_ret(lock, value, nil, 3)
 end
 
 


### PR DESCRIPTION
`get()` now returns a third value (number) which indicates at which
level of cache a value was retrieved.

- `1`: from the Lua-land LRU
- `2`: from the shm (also the returned value when a worker was waiting
  on the mutex of another worker's callback already running)
- `3`: from the callback (we were the worker that owned the cb mutex)