### PR TITLE
feat(mlcache) accept user-provided LRU instances

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -158,17 +158,16 @@ function _M.new(shm, opts)
         return nil, "no such lua_shared_dict: " .. shm
     end
 
-    local lru = lrucache.new(opts.lru_size or 100)
-
     local self          = {
-        lru             = lru,
-        namespace       = fmt("%p", lru),
+        lru             = opts.lru     or lrucache.new(opts.lru_size or 100),
         dict            = dict,
         shm             = shm,
         ttl             = opts.ttl     or 30,
         neg_ttl         = opts.neg_ttl or 5,
         resty_lock_opts = opts.resty_lock_opts,
     }
+
+    self.namespace = fmt("%p", self)
 
     if opts.ipc_shm then
         local mlcache_ipc = require "resty.mlcache.ipc"

--- a/t/01-new.t
+++ b/t/01-new.t
@@ -241,3 +241,27 @@ number
 number
 --- no_error_log
 [error]
+
+
+
+=== TEST 10: new() accepts user-provided LRU instances
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache          = require "resty.mlcache"
+            local pureffi_lrucache = require "resty.lrucache.pureffi"
+
+            local my_lru = pureffi_lrucache.new(100)
+
+            local cache = assert(mlcache.new("cache", { lru = my_lru }))
+
+            ngx.say("lru is user-provided: ", cache.lru == my_lru)
+        }
+    }
+--- request
+GET /t
+--- response_body
+lru is user-provided: true
+--- no_error_log
+[error]


### PR DESCRIPTION
A useful features if one wishes, for instance, to use the pureffi
implementation of lua-resty-lrucache, or any other homemade
implementation.