### PR TITLE
add support for overriding ttl / neg_ttl with second return value of callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Fast multi-level key/value cache for OpenResty.
 
 - Can cache scalar Lua types and tables.
-- Provides automatic caching level fallbacks: LRU > shm > callback.
-- Can invalidate cached entities accross workers via a custom IPC
+- Provides automatic caching level fallback: LRU > shm > callback.
+- Can invalidate cached entities across workers via a custom IPC
   (inter-process communication) module.
 
 The cache level hierarchy is:

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -348,10 +348,6 @@ function _M:get(key, opts, cb, ...)
         error("callback must be a function", 2)
     end
 
-    -- opts validation
-
-    local ttl, neg_ttl = check_opts(self, opts)
-
     -- worker LRU cache retrieval
 
     local data = self.lru:get(key)
@@ -411,6 +407,10 @@ function _M:get(key, opts, cb, ...)
 
         return unlock_and_ret(lock, data, nil, 2)
     end
+
+    -- opts validation
+
+    local ttl, neg_ttl = check_opts(self, opts)
 
     -- still not in shm, we are responsible for running the callback
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -422,7 +422,7 @@ function _M:get(key, opts, cb, ...)
 
     -- override ttl / neg_ttl
 
-    if new_ttl and type(new_ttl) == "number" and new_ttl >= 0 then
+    if type(new_ttl) == "number" and new_ttl >= 0 then
         if data == nil then
             neg_ttl = new_ttl
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -382,6 +382,10 @@ function _M:get(key, opts, cb, ...)
     -- not in shm either
     -- single worker must execute the callback
 
+    -- opts validation
+
+    local ttl, neg_ttl = check_opts(self, opts)
+
     local lock, err = resty_lock:new(self.shm, self.resty_lock_opts)
     if not lock then
         return nil, "could not create lock: " .. err
@@ -406,10 +410,6 @@ function _M:get(key, opts, cb, ...)
 
         return unlock_and_ret(lock, data, nil, 2)
     end
-
-    -- opts validation
-
-    local ttl, neg_ttl = check_opts(self, opts)
 
     -- still not in shm, we are responsible for running the callback
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -414,12 +414,23 @@ function _M:get(key, opts, cb, ...)
 
     -- still not in shm, we are responsible for running the callback
 
-    local ok, err = pcall(cb, ...)
+    local ok, err, new_ttl = pcall(cb, ...)
     if not ok then
         return unlock_and_ret(lock, nil, "callback threw an error: " .. err)
     end
 
     data = err
+
+    -- override ttl / neg_ttl
+
+    if new_ttl and type(new_ttl) == "number" and new_ttl >= 0 then
+        if data == nil then
+            neg_ttl = new_ttl
+
+        else
+            ttl = new_ttl
+        end
+    end
 
     -- set shm cache level
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -293,28 +293,27 @@ local function check_opts(self, opts)
             error("opts must be a table", 3)
         end
 
-        if opts.ttl ~= nil then
-            if type(opts.ttl) ~= "number" then
+        ttl = opts.ttl
+        if ttl ~= nil then
+            if type(ttl) ~= "number" then
                 error("opts.ttl must be a number", 3)
             end
 
-            if opts.ttl < 0 then
+            if ttl < 0 then
                 error("opts.ttl must be >= 0", 3)
             end
         end
 
-        if opts.neg_ttl ~= nil then
-            if type(opts.neg_ttl) ~= "number" then
+        neg_ttl = opts.neg_ttl
+        if neg_ttl ~= nil then
+            if type(neg_ttl) ~= "number" then
                 error("opts.neg_ttl must be a number", 3)
             end
 
-            if opts.neg_ttl < 0 then
+            if neg_ttl < 0 then
                 error("opts.neg_ttl must be >= 0", 3)
             end
         end
-
-        ttl     = opts.ttl
-        neg_ttl = opts.neg_ttl
     end
 
     if not ttl then

--- a/lib/resty/mlcache/ipc.lua
+++ b/lib/resty/mlcache/ipc.lua
@@ -13,6 +13,7 @@ local find         = string.find
 local min          = math.min
 local type         = type
 local pcall        = pcall
+local error        = error
 local insert       = table.insert
 local tonumber     = tonumber
 local setmetatable = setmetatable

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -1422,7 +1422,7 @@ in callback 2
             assert(err == nil, err)
             assert(data == nil)
 
-            local data, err = cache:get("neg_key", opts, neg_cb)
+            data, err = cache:get("neg_key", opts, neg_cb)
             assert(err == nil, err)
             assert(data == nil)
 

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -1326,7 +1326,7 @@ qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):10 loop\]/
             assert(err == nil, err)
             assert(data == 1)
 
-            ngx.sleep(0.1)
+            ngx.sleep(0.15)
 
             data, err = cache:get("key", opts, cb2)
             assert(err == nil, err)
@@ -1371,7 +1371,7 @@ in callback 2
             assert(err == nil, err)
             assert(data == nil)
 
-            ngx.sleep(0.1)
+            ngx.sleep(0.15)
 
             data, err = cache:get("key", opts, cb2)
             assert(err == nil, err)
@@ -1416,7 +1416,7 @@ in callback 2
             assert(err == nil, err)
             assert(data == 1)
 
-            ngx.sleep(0.1)
+            ngx.sleep(0.15)
 
             data, err = cache:get("pos_key", opts, neg_cb)
             assert(err == nil, err)
@@ -1430,7 +1430,7 @@ in callback 2
             assert(err == nil, err)
             assert(data == nil)
 
-            ngx.sleep(0.1)
+            ngx.sleep(0.15)
 
             data, err = cache:get("neg_key", opts, pos_cb)
             assert(err == nil, err)

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -1343,7 +1343,7 @@ in callback 2
 
 
 
-=== TEST 30: get() allows callback second return value overriding neg_ttl
+=== TEST 31: get() allows callback second return value overriding neg_ttl
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1388,7 +1388,7 @@ in callback 2
 
 
 
-=== TEST 30: get() ignores invalid callback second return value
+=== TEST 32: get() ignores invalid callback second return value
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {


### PR DESCRIPTION
This PR contains a few fixes / adjustments, but most importantly it adds support for callback function to override `ttl` or `neg_ttl`. This is useful when the expiration time or negative expiration time is not known before callback OR when the knowledge is actually in callback.

One such scenario that I did run recently is caching of 3rd party issued OAuth 2.0 access tokens. You may want to cache the OAuth 2.0 token endpoint HTTP requests, but you want to cache the tokens retrieved from such endpoint only as long as the provider says they will be valid, and I'm especially referencing this: https://tools.ietf.org/html/rfc6749#appendix-A.14. It also allows different TTL for different types of authentication methods, and allows the TTL to be changed outside Kong (in my example), on a 3rd party IdP.