### PR TITLE
Add a callback to customize the value before LRU cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ holding the desired options for this instance. The possible options are:
   workers. Several mlcache instances can use the same `ipc_shm` (events will
   be namespaced).
 - `l1_serializer`: function used to transform the values before setting them
-  in the LRU cache (L1). It might bev useful to store arbitrary Lua objects
+  in the LRU cache (L1). It might be useful to store arbitrary Lua objects
   such as cdata objects, functions, ... This function is called for every L1
   miss, in every worker.
-  **Default** no transformation
+  **Default:** no transformation
 
 Example:
 
@@ -291,6 +291,10 @@ options:
   misses (when the L3 callback returns `nil`). The unit is seconds, but
   accepts fractional number parts, like `0.3`. A `neg_ttl` of `0` means the
   cached misses will never expire.
+  **Default:** inherited from the instance.
+- `l1_serializer`: function used to transform the values before setting them
+  in the LRU cache (L1). It might be useful to store arbitrary Lua objects
+  such as cdata objects, functions, ... This function is called on L1 miss.
   **Default:** inherited from the instance.
 
 The third argument `callback` **must** be a function. Its signature and return
@@ -458,7 +462,8 @@ one of [get()](#get).
 
 The third argument `value` is the value to cache, similar to the return value
 of the L3 callback. Just like the callback's return value, it must be a Lua
-scalar, a table, or `nil`.
+scalar, a table, or `nil`. It a `l1_serializer` is provided either from the
+constructor or in the `opts` argument, it will be called with `value`.
 
 On failure, this method returns `nil` and a string describing the error.
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,15 @@ holding the desired options for this instance. The possible options are:
   be used as a pub/sub backend for invalidation events propagation across
   workers. Several mlcache instances can use the same `ipc_shm` (events will
   be namespaced).
-- `l1_serializer`: function used to transform the values before setting them
-  in the LRU cache (L1). It might be useful to store arbitrary Lua objects
-  such as cdata objects, functions, ... This function is called for every L1
-  miss, in every worker.
-  **Default:** no transformation
+- `l1_serializer`: an _optional_ function. Its signature and accepted values
+  are documented under the [get()](#get) method, along with an example.
+  If specified, this function will be called by each worker every time the L1
+  LRU cache is a miss and the value needs to be fetched from a lower cache
+  level (L2/L3).
+  Its purpose is to perform arbitrary serialization of the cached item to
+  transform it into any Lua object _before_ storing it into the L1 LRU cache.
+  It can thus avoid your application from having to repeat such transformation
+  upon every cache hit, such as creating tables, cdata objects, functions, etc...
 
 Example:
 
@@ -292,10 +296,15 @@ options:
   accepts fractional number parts, like `0.3`. A `neg_ttl` of `0` means the
   cached misses will never expire.
   **Default:** inherited from the instance.
-- `l1_serializer`: function used to transform the values before setting them
-  in the LRU cache (L1). It might be useful to store arbitrary Lua objects
-  such as cdata objects, functions, ... This function is called on L1 miss.
-  **Default:** inherited from the instance.
+- `l1_serializer`: an _optional_ function. Its signature and accepted values
+  are documented in the example below.
+  If specified, this function will be called by each worker every time the L1
+  LRU cache is a miss and the value needs to be fetched from a lower cache
+  level (L2/L3).
+  Its purpose is to perform arbitrary serialization of the cached item to
+  transform it into any Lua object _before_ storing it into the L1 LRU cache.
+  It can thus avoid your application from having to repeat such transformation
+  upon every cache hit, such as creating tables, cdata objects, functions, etc...
 
 The third argument `callback` **must** be a function. Its signature and return
 values are documented in the following example:
@@ -329,15 +338,17 @@ When called, `get()` follows the below steps:
 2. query the L2 cache (`lua_shared_dict` shared memory zone). This cache is
    shared by all workers, and is less efficient than the L1 cache. It also
    involves serialization for Lua tables.
-    1. if the L2 cache has the value, it calls the `l1_serializer` function,
-       sets the resulting value in the L1 cache, and returns it.
+    1. if the L2 cache has the value, retrieve it.
+        1. if l1_serializer is set, run it, and set the resulting value in the
+           L1 cache
+        2. if not, directly set the value as-is in the L1 cache
     2. if the L2 cache does not have the value (L2 miss), it continues.
 3. creates a [lua-resty-lock], and ensures that a single worker will run
    the callback (other workers trying to access the same value will wait).
 4. a single worker runs the L3 callback.
 5. the callback returns (ex: it performed a database query), and the worker
-   sets the value in the L2 cache, calls the `l1_serializer`, sets the resulting
-   value in the L1 cache, and returns it.
+   sets the value in the L2 cache. It then sets it in its L1 cache as well
+   (as-is by default, or as returned by `l1_serializer` is specified).
 6. other workers that were trying to access the same value but were waiting
    fetch the value from the L2 cache (they do not run the L3 callback) and
    return it.
@@ -381,6 +392,49 @@ else
     ngx.say("user does not exists")
 end
 ```
+
+This second example is the modification of the above one, in which we apply
+some transformation to the retrieved `user` record, and cache it via the
+`l1_serializer` callback:
+
+```lua
+-- Our l1_serializer, called upon an L1 miss, when L2 or L3 return a hit.
+--
+-- Its signature accepts a single argument: the item as returned from
+-- an L2 hit. Therefore, this argument can never be `nil`. The result will be
+-- kept in the L1 LRU cache, but the result cannot be `nil`.
+--
+-- Just like the `callback` argument, it runs in protected mode and
+-- can throw Lua errors which will be caught and logged by this module.
+local function compile_custom_code(user_row)
+    if user_row.custom_code ~= nil then
+        local compiled, err = loadstring(user_row.custom_code)
+        if not compiled then
+            -- in this case, nothing will be stored in the cache (as if the L3
+            -- callback failed). This means that if the same operation is
+            -- attempted and the same data is returned, it will fail again.
+            -- Depending on the situation it might not be desireable, and
+            -- storing a default value would be a better option.
+            error("failed to compile custom code: " .. err)
+        end
+        user_row.custom_code = compiled
+    end
+
+    return user_row
+end
+
+local user, err = cache:get("users:" .. user_id,
+                            { l1_serializer = compile_custom_code },
+                            fetch_user, db, user_id)
+if err then
+     ngx.log(ngx.ERR, "could not retrieve user: ", err)
+     return
+end
+
+-- now we have a ready-to-call function
+user.custom_code()
+```
+
 
 [Back to TOC](#table-of-contents)
 
@@ -462,8 +516,9 @@ one of [get()](#get).
 
 The third argument `value` is the value to cache, similar to the return value
 of the L3 callback. Just like the callback's return value, it must be a Lua
-scalar, a table, or `nil`. It a `l1_serializer` is provided either from the
-constructor or in the `opts` argument, it will be called with `value`.
+scalar, a table, or `nil`. If a `l1_serializer` is provided either from the
+constructor or in the `opts` argument, it will be called with `value` if the
+later is not `nil`.
 
 On failure, this method returns `nil` and a string describing the error.
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ holding the desired options for this instance. The possible options are:
   be used as a pub/sub backend for invalidation events propagation across
   workers. Several mlcache instances can use the same `ipc_shm` (events will
   be namespaced).
-- `lru_callback`: function used to transform the values before setting them
+- `l1_serializer`: function used to transform the values before setting them
   in the LRU cache (L1). It might bev useful to store arbitrary Lua objects
   such as cdata objects, functions, ... This function is called for every L1
   miss, in every worker.
@@ -325,14 +325,14 @@ When called, `get()` follows the below steps:
 2. query the L2 cache (`lua_shared_dict` shared memory zone). This cache is
    shared by all workers, and is less efficient than the L1 cache. It also
    involves serialization for Lua tables.
-    1. if the L2 cache has the value, it calls the `lru_callback` function,
+    1. if the L2 cache has the value, it calls the `l1_serializer` function,
        sets the resulting value in the L1 cache, and returns it.
     2. if the L2 cache does not have the value (L2 miss), it continues.
 3. creates a [lua-resty-lock], and ensures that a single worker will run
    the callback (other workers trying to access the same value will wait).
 4. a single worker runs the L3 callback.
 5. the callback returns (ex: it performed a database query), and the worker
-   sets the value in the L2 cache, calls the `lru_callback`, sets the resulting
+   sets the value in the L2 cache, calls the `l1_serializer`, sets the resulting
    value in the L1 cache, and returns it.
 6. other workers that were trying to access the same value but were waiting
    fetch the value from the L2 cache (they do not run the L3 callback) and

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -280,6 +280,8 @@ local function set_lru(self, key, value, ttl, neg_ttl)
         ok, value = pcall(self.lru_callback, value)
         if not ok then
             return nil, 'lru_callback threw an error: ' .. value
+        elseif value == nil then
+            return nil, 'lru_callback returned a nil value'
         end
     end
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -180,10 +180,10 @@ function _M.new(name, shm, opts)
             error("opts.ipc_shm must be a string", 2)
         end
 
-        if opts.lru_callback ~= nil
-            and type(opts.lru_callback) ~= "function"
+        if opts.l1_serializer ~= nil
+            and type(opts.l1_serializer) ~= "function"
         then
-            error("opts.lru_callback must be a function")
+            error("opts.l1_serializer must be a function")
         end
     else
         opts = {}
@@ -201,7 +201,7 @@ function _M.new(name, shm, opts)
         ttl             = opts.ttl     or 30,
         neg_ttl         = opts.neg_ttl or 5,
         resty_lock_opts = opts.resty_lock_opts,
-        lru_callback    = opts.lru_callback,
+        l1_serializer   = opts.l1_serializer,
     }
 
     if opts.ipc_shm then
@@ -275,13 +275,13 @@ local function set_lru(self, key, value, ttl, neg_ttl)
         ttl = nil
     end
 
-    if self.lru_callback then
+    if self.l1_serializer then
         local ok
-        ok, value = pcall(self.lru_callback, value)
+        ok, value = pcall(self.l1_serializer, value)
         if not ok then
-            return nil, "lru_callback threw an error: " .. value
+            return nil, "l1_serializer threw an error: " .. value
         elseif value == nil then
-            return nil, "lru_callback returned a nil value"
+            return nil, "l1_serializer returned a nil value"
         end
     end
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -276,12 +276,16 @@ local function set_lru(self, key, value, ttl, neg_ttl, l1_serializer)
     end
 
     if l1_serializer then
-        local ok
-        ok, value = pcall(l1_serializer, value)
+        local ok, err
+        ok, value, err = pcall(l1_serializer, value)
         if not ok then
             return nil, "l1_serializer threw an error: " .. value
         elseif value == nil then
-            return nil, "l1_serializer returned a nil value"
+            if err then
+                return nil, "l1_serializer returned an error: " .. err
+            else
+                return nil, "l1_serializer returned a nil value"
+            end
         end
     end
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -181,7 +181,7 @@ function _M.new(name, shm, opts)
         end
 
         if opts.lru_callback ~= nil
-            and type(opts.lru_callback) ~= 'function'
+            and type(opts.lru_callback) ~= "function"
         then
             error("opts.lru_callback must be a function")
         end
@@ -279,9 +279,9 @@ local function set_lru(self, key, value, ttl, neg_ttl)
         local ok
         ok, value = pcall(self.lru_callback, value)
         if not ok then
-            return nil, 'lru_callback threw an error: ' .. value
+            return nil, "lru_callback threw an error: " .. value
         elseif value == nil then
-            return nil, 'lru_callback returned a nil value'
+            return nil, "lru_callback returned a nil value"
         end
     end
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -183,7 +183,7 @@ function _M.new(name, shm, opts)
         if opts.l1_serializer ~= nil
             and type(opts.l1_serializer) ~= "function"
         then
-            error("opts.l1_serializer must be a function")
+            error("opts.l1_serializer must be a function", 2)
         end
     else
         opts = {}
@@ -546,10 +546,12 @@ function _M:get(key, opts, cb, ...)
     -- set our own worker's LRU cache
 
     data, err = set_lru(self, key, data, ttl, neg_ttl, l1_serializer)
-    if data == CACHE_MISS_SENTINEL_LRU then
-        data = nil -- convert misses back to nil for return values
-    elseif err then
+    if err then
         return unlock_and_ret(lock, nil, err)
+    end
+
+    if data == CACHE_MISS_SENTINEL_LRU then
+        return unlock_and_ret(lock, nil, nil, 3)
     end
 
     -- unlock and return

--- a/t/08-lru-callback.t
+++ b/t/08-lru-callback.t
@@ -245,7 +245,7 @@ lru_callback threw an error: .*?: cannot deserialize
             end
 
             local ok, err = cache:get("key", nil, function() return "foo" end)
-            assert(not ok, 'get call returned successfully')
+            assert(not ok, "get call returned successfully")
             ngx.say(err)
         }
     }

--- a/t/08-lru-callback.t
+++ b/t/08-lru-callback.t
@@ -1,0 +1,227 @@
+# vim:set ts=4 sts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+workers(2);
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict  cache_shm 1m;
+
+    init_by_lua_block {
+        -- local verbose = true
+        local verbose = false
+        local outfile = "$Test::Nginx::Util::ErrLogFile"
+        -- local outfile = "/tmp/v.log"
+        if verbose then
+            local dump = require "jit.dump"
+            dump.on(nil, outfile)
+        else
+            local v = require "jit.v"
+            v.on(outfile)
+        end
+
+        require "resty.core"
+        -- jit.opt.start("hotloop=1")
+        -- jit.opt.start("loopunroll=1000000")
+        -- jit.off()
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: lru_callback is called on cache misses
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", {
+                lru_callback = function(s)
+                    return string.format("deserialize(%q)", s)
+                end,
+            })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local data, err = cache:get("key", nil, function() return "foo" end)
+            if not data then
+                ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+deserialize("foo")
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: lru_callback is not called on L1 hits
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local calls = 0
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", {
+                lru_callback = function(s)
+                    calls = calls + 1
+                    return string.format("deserialize(%q)", s)
+                end,
+            })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            for i=1, 3 do
+                local data, err = cache:get("key", nil, function() return "foo" end)
+                if not data then
+                    ngx.say(err)
+                end
+                ngx.say(data)
+            end
+            ngx.say("calls: ", calls)
+        }
+    }
+--- request
+GET /t
+--- response_body
+deserialize("foo")
+deserialize("foo")
+deserialize("foo")
+calls: 1
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: lru_callback is called on L2 hits
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local calls = 0
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", {
+                lru_callback = function(s)
+                    calls = calls + 1
+                    return string.format("deserialize(%q)", s)
+                end,
+            })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            for i=1, 3 do
+                local data, err = cache:get("key", nil, function() return "foo" end)
+                if not data then
+                    ngx.say(err)
+                end
+                ngx.say(data)
+                cache.lru:delete("key")
+            end
+            ngx.say("calls: ", calls)
+        }
+    }
+--- request
+GET /t
+--- response_body
+deserialize("foo")
+deserialize("foo")
+deserialize("foo")
+calls: 3
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: lru_callback is called in protected mode (L2 miss)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", {
+                lru_callback = function(s)
+                    error("cannot deserialize")
+                end,
+            })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local data, err = cache:get("key", nil, function() return "foo" end)
+            if not data then
+                ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+lru_callback threw an error: .*?: cannot deserialize
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: lru_callback is called in protected mode (L2 hit)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local called = false
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", {
+                lru_callback = function(s)
+                    if called then error("cannot deserialize") end
+                    called = true
+                    return string.format("deserialize(%q)", s)
+                end,
+            })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            assert(cache:get("key", nil, function() return "foo" end))
+            cache.lru:delete("key")
+
+            local data, err = cache:get("key", nil, function() return "foo" end)
+            if not data then
+                ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+lru_callback threw an error: .*?: cannot deserialize
+--- no_error_log
+[error]
+


### PR DESCRIPTION
This PR fixes #7: it adds a `lru_callback` option to the mlcache constructor in order to be able to store arbitrary values (we use it to cache functions and cdata objects mostly).

I am open to discuss about the API: I added it in the constructor rather than in the `get` method to not bloat it too much, but it could also go in the `opts` parameter.

In practice, we tend to store always the same kind of data in the same mlcache instance, so this API works for my use case while keeping the `get` method reasonably simple, but I would be happy to hear about other possible workflows.