### PR TITLE
fix(mlcache) do not error out on 'no memory'

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ holding the desired options for this instance. The possible options are:
   cache.  It can thus avoid your application from having to repeat such
   transformation upon every cache hit, such as creating tables, cdata objects,
   functions, etc...
+- `shm_set_tries`: the number of tries for the lua_shared_dict `set()`
+  operation. When the lua_shared_dict is full, it attempts to free up to 30
+  items from its queue. When the value being set is much larger than the freed
+  space, this option allows mlcache to retry the operation (and free more slots)
+  until the maximum number of tries is reached or enough memory was freed for
+  the value to fit.
+  **Default**: `3`.
 - `ipc_shm`: _optional_ string. If you wish to use [set()](#set),
   [delete()](#delete), or [purge()](#purge), you must provide an IPC
   (Inter-process communication) mechanism for workers to invalidate their L1

--- a/t/01-new.t
+++ b/t/01-new.t
@@ -472,27 +472,37 @@ opts.resty_lock_opts must be a table
 
 
 
-=== TEST 18: new() validates opts.quiet
+=== TEST 18: new() validates opts.shm_set_tries
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
         content_by_lua_block {
             local mlcache = require "resty.mlcache"
 
-            local ok, err = pcall(mlcache.new, "name", "cache_shm", {
-                quiet = 123,
-            })
-            if not ok then
-                ngx.log(ngx.ERR, err)
+            local values = {
+                false,
+                -1,
+                0,
+            }
+
+            for _, v in ipairs(values) do
+                local ok, err = pcall(mlcache.new, "name", "cache_shm", {
+                    shm_set_tries = v,
+                })
+                if not ok then
+                    ngx.say(err)
+                end
             end
         }
     }
 --- request
 GET /t
 --- response_body
-
---- error_log
-opts.quiet must be a boolean
+opts.shm_set_tries must be a number
+opts.shm_set_tries must be >= 1
+opts.shm_set_tries must be >= 1
+--- no_error_log
+[error]
 
 
 

--- a/t/01-new.t
+++ b/t/01-new.t
@@ -472,7 +472,31 @@ opts.resty_lock_opts must be a table
 
 
 
-=== TEST 18: new() creates an mlcache object with default attributes
+=== TEST 18: new() validates opts.quiet
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local ok, err = pcall(mlcache.new, "name", "cache_shm", {
+                quiet = 123,
+            })
+            if not ok then
+                ngx.log(ngx.ERR, err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log
+opts.quiet must be a boolean
+
+
+
+=== TEST 19: new() creates an mlcache object with default attributes
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -500,7 +524,7 @@ number
 
 
 
-=== TEST 19: new() accepts user-provided LRU instances via opts.lru
+=== TEST 20: new() accepts user-provided LRU instances via opts.lru
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {


### PR DESCRIPTION
When the shm is full and eviction must happen through the LRU mechanism,
it could be that the removed values do not free a large enough amount of
memory in the shm, thus leading `set()` to fail and return a "no memory"
error.

This can happen when values being stored have sizes of different orders of
magnitude.

We now ignore such errors, so that the user can still retrieve the data
and benefit from it in the L1 cache which does not suffer from such a
limitation.

We print a warning notice when such errors occur, but a new `opts.quiet`
option can disable this behavior.