### PR TITLE
fix(*) handle shm_miss option in methods other than get()

### DIFF
--- a/t/06-delete.t
+++ b/t/06-delete.t
@@ -13,8 +13,9 @@ my $pwd = cwd();
 
 our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
-    lua_shared_dict  cache_shm 1m;
-    lua_shared_dict  ipc_shm   1m;
+    lua_shared_dict  cache_shm      1m;
+    lua_shared_dict  cache_shm_miss 1m;
+    lua_shared_dict  ipc_shm        1m;
 };
 
 run_tests();
@@ -136,7 +137,89 @@ from callback: 456
 
 
 
-=== TEST 4: delete() calls broadcast with invalidated key
+=== TEST 4: delete() removes a cached nil from shm_miss if specified
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache = assert(mlcache.new("my_mlcache", "cache_shm", {
+                ipc_shm = "ipc_shm",
+                shm_miss = "cache_shm_miss",
+            }))
+
+            local value = nil
+
+            local function cb()
+                ngx.say("in callback")
+                return value
+            end
+
+            -- set a value (callback call)
+
+            local data, err = cache:get("key", nil, cb)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+            ngx.say("from callback: ", data)
+
+            -- get a value (no callback call)
+
+            data, err = cache:get("key", nil, cb)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+            ngx.say("from LRU: ", data)
+
+            -- test if value is set from shm (safer to check due to the key)
+
+            local v = ngx.shared.cache_shm_miss:get(cache.name .. "key")
+            ngx.say("shm_miss has value before delete: ", v ~= nil)
+
+            -- delete the value
+
+            assert(cache:delete("key"))
+
+            local v = ngx.shared.cache_shm_miss:get(cache.name .. "key")
+            ngx.say("shm_miss has value after delete: ", v ~= nil)
+
+            -- ensure LRU was also deleted
+
+            v = cache.lru:get("key")
+            ngx.say("from LRU: ", v)
+
+            -- start over from callback again
+
+            value = 456
+
+            data, err = cache:get("key", nil, cb)
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+            ngx.say("from callback again: ", data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+in callback
+from callback: nil
+from LRU: nil
+shm_miss has value before delete: true
+shm_miss has value after delete: false
+from LRU: nil
+in callback
+from callback again: 456
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: delete() calls broadcast with invalidated key
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {

--- a/t/08-purge.t
+++ b/t/08-purge.t
@@ -12,8 +12,9 @@ my $pwd = cwd();
 
 our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
-    lua_shared_dict  cache_shm 1m;
-    lua_shared_dict  ipc_shm   1m;
+    lua_shared_dict  cache_shm      1m;
+    lua_shared_dict  cache_shm_miss 1m;
+    lua_shared_dict  ipc_shm        1m;
 };
 
 run_tests();
@@ -128,7 +129,55 @@ ok
 
 
 
-=== TEST 4: purge() does not call shm:flush_expired() by default
+=== TEST 4: purge() deletes all items from shm_miss is specified
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache = assert(mlcache.new("my_mlcache", "cache_shm", {
+                ipc_shm = "ipc_shm",
+                shm_miss = "cache_shm_miss",
+            }))
+
+            -- populate mlcache
+
+            for i = 1, 100 do
+                local _, err = cache:get(tostring(i), nil, function() return nil end)
+                if err then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+            end
+
+            -- purge
+
+            assert(cache:purge())
+
+            local called = 0
+
+            for i = 1, 100 do
+                local value, err = cache:get(tostring(i), nil, function() return i end)
+
+                if value ~= i then
+                    ngx.say("key ", i, " had: ", value)
+                end
+            end
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: purge() does not call shm:flush_expired() by default
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -163,7 +212,7 @@ flush_expired called with 'max_count'
 
 
 
-=== TEST 5: purge() calls shm:flush_expired() if argument specified
+=== TEST 6: purge() calls shm:flush_expired() if argument specified
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -200,7 +249,46 @@ flush_expired called with 'max_count': nil
 
 
 
-=== TEST 6: purge() calls broadcast() on purge channel
+=== TEST 7: purge() calls shm:flush_expired() if shm_miss is specified
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            do
+                local cache_shm = ngx.shared.cache_shm
+                local mt = getmetatable(cache_shm)
+                local orig_cache_shm_flush_expired = mt.flush_expired
+
+                mt.flush_expired = function(self, ...)
+                    local arg = { ... }
+                    local n = arg[1]
+                    ngx.say("flush_expired called with 'max_count': ", n)
+
+                    return orig_cache_shm_flush_expired(self, ...)
+                end
+            end
+
+            local mlcache = require "resty.mlcache"
+
+            local cache = assert(mlcache.new("my_mlcache", "cache_shm", {
+                ipc_shm = "ipc_shm",
+                shm_miss = "cache_shm_miss",
+            }))
+
+            assert(cache:purge(true))
+        }
+    }
+--- request
+GET /t
+--- response_body
+flush_expired called with 'max_count': nil
+flush_expired called with 'max_count': nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: purge() calls broadcast() on purge channel
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {


### PR DESCRIPTION
Sadly, the new 'shm_miss' option introduced in #42 did not properly
handle this new shm in the following methods:

* set()
* delete()
* peek()
* purge()

This introduces the necessary fixes and tests.