### PR TITLE
feat(get) return & resurrect stale data on soft callback errors

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -366,7 +366,20 @@ local function set_lru(self, key, value, ttl, neg_ttl, l1_serializer)
 end
 
 
-local function shm_set_retries(shm, dict, key, val, ttl, max_tries)
+local function shm_set_retries(self, shm_key, shm_value, flags, is_nil, ttl,
+                               neg_ttl, shm_set_tries)
+    local shm = self.shm
+    local dict = self.dict
+
+    if is_nil then
+        ttl = neg_ttl
+
+        if self.dict_miss then
+            shm = self.shm_miss
+            dict = self.dict_miss
+        end
+    end
+
     -- we will call `set()` N times to work around potential shm fragmentation.
     -- when the shm is full, it will only evict about 30 to 90 items (via
     -- LRU), which could lead to a situation where `set()` still does not
@@ -376,10 +389,10 @@ local function shm_set_retries(shm, dict, key, val, ttl, max_tries)
     local tries = 0
     local ok, err
 
-    while tries < max_tries do
+    while tries < shm_set_tries do
         tries = tries + 1
 
-        ok, err = dict:set(key, val, ttl)
+        ok, err = dict:set(shm_key, shm_value, ttl, flags or 0)
         if ok or err and err ~= "no memory" then
             break
         end
@@ -401,24 +414,11 @@ local function shm_set_retries(shm, dict, key, val, ttl, max_tries)
 end
 
 
-local function set_shm(self, shm_key, value, ttl, neg_ttl, shm_set_tries)
+local function marshall_for_shm(value, ttl, neg_ttl)
     local at = now()
 
     if value == nil then
-        local shm_nil_marshalled = marshallers.shm_nil(at, neg_ttl)
-
-        local shm = self.shm_miss or self.shm
-        local dict = self.dict_miss or self.dict
-
-        -- we need to cache that this was a miss, and ensure cache hit for a
-        -- nil value
-        local ok, err = shm_set_retries(shm, dict, shm_key, shm_nil_marshalled,
-                                        neg_ttl, shm_set_tries)
-        if not ok then
-            return nil, err
-        end
-
-        return true
+        return marshallers.shm_nil(at, neg_ttl), nil, true -- is_nil
     end
 
     -- serialize insertion time + Lua types for shm storage
@@ -435,18 +435,19 @@ local function set_shm(self, shm_key, value, ttl, neg_ttl, shm_set_tries)
                     .. err
     end
 
-    local shm_marshalled = marshallers.shm_value(str_marshalled, value_type,
-                                                 at, ttl)
+    return marshallers.shm_value(str_marshalled, value_type, at, ttl)
+end
 
-    -- cache value in shm for currently-locked workers
 
-    local ok, err = shm_set_retries(self.shm, self.dict, shm_key,
-                                    shm_marshalled, ttl, shm_set_tries)
-    if not ok then
+
+local function set_shm(self, shm_key, value, ttl, neg_ttl, shm_set_tries)
+    local shm_value, err, is_nil = marshall_for_shm(value, ttl, neg_ttl)
+    if not shm_value then
         return nil, err
     end
 
-    return true
+    return shm_set_retries(self, shm_key, shm_value, nil, is_nil, ttl, neg_ttl,
+                           shm_set_tries)
 end
 
 


### PR DESCRIPTION
When the callback returns a soft error (`nil + err`), we assume it to be
the cause of an I/O error (e.g. timeout, connection refused...).

The previous behavior in such a case is to return `ret1 + err` to the
caller, as:
```lua
    local data, err = cache:get("key", opts, callback_fn)
    if err then
        ngx.log(ngx.ERR, "callback returned: ", err)
        return
    end
```

1. Not only are we preventing the user from accessing a value that might
   still be in the cache
2. We are also not hitting that value anymore, thus increasing its
   chances of being evicted, which is _wrong_, since once it is evicted, we will
   never be able to retrieve it anymore (the callback returns errors).

Instead, we shall:

1. Always return cached values from `:get()`, even if they are stale
2. Treat such stale values as VIPs, since they become critical for the
   host application's resiliency.

Thus, this patch follows this rationale:

* We do not wish to add anymore complexity to `:get()`, which is close
  to be bloated with options, so no additional option and complexity
  should be added.
* We assume that the desired behavior of any user of this library is
  maximum resiliency.
* Upon any callback error, if we are lucky to see any stale data still
  cached, consider it as "stale value".
    * stale values are cached forever in shm (L2).
    * stale values are *never* cached in LRU (L1).
    * all accesses to stale values trigger the L3 callback. The I/O
      could succeed. The host application can make decisions such as
      increasing, reducing the timeout, connecting to a different
      endpoint, etc...
    * we notify the user that the retrieved value is stale, along with
      the callback error (if not callback error, then the value is
      fresh, obviously).

Example:
```lua
    local data, err, hit_lvl, stale = cache:get("key", opts, callback_fn)
    if err then
        if stale then
            -- there was an error, but the value was still cached, this
            -- is our lucky day
        end

        -- callback errored out, and no cached value
    end
```

Fix #50

![Resurrection](http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=265&type=card)

# TODO

- [ ] Tests!
- [ ] Support for stale values in `peek()`