### PR TITLE
feat: add option to isolate resty locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ holding the desired options for this instance. The possible options are:
 - `resty_lock_opts`: options for [lua-resty-lock] instances. When mlcache runs
   the L3 callback, it uses lua-resty-lock to ensure that a single worker runs
   the provided callback.
+- `shm_locks`: _optional_ string. The name of a `lua_shared_dict`. When
+  specified, lua-resty-lock will use this shared dict to store its locks. This
+  option can help reducing cache churning: when the L2 cache (shm) is full,
+  every insertion (such as locks created by concurrent accesses triggering L3
+  callbacks) purges the oldest 30 accessed items. These purged items are most
+  likely to be previously (and valuable) cached values. By isolating locks in a
+  separate shared dict, workloads experiencing cache churning can mitigate this
+  effect.
 - `l1_serializer`: an _optional_ function. Its signature and accepted values
   are documented under the [get()](#get) method, along with an example.  If
   specified, this function will be called by each worker every time the L1 LRU

--- a/t/11-locks_shm.t
+++ b/t/11-locks_shm.t
@@ -1,0 +1,115 @@
+# vim:set ts=4 sts=4 sw=4 et ft=:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict  cache_shm 1m;
+    lua_shared_dict  locks_shm 1m;
+
+    init_by_lua_block {
+        -- local verbose = true
+        local verbose = false
+        local outfile = "$Test::Nginx::Util::ErrLogFile"
+        -- local outfile = "/tmp/v.log"
+        if verbose then
+            local dump = require "jit.dump"
+            dump.on(nil, outfile)
+        else
+            local v = require "jit.v"
+            v.on(outfile)
+        end
+
+        require "resty.core"
+        -- jit.opt.start("hotloop=1")
+        -- jit.opt.start("loopunroll=1000000")
+        -- jit.off()
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: new() validates opts.shm_locks
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local ok, err = pcall(mlcache.new, "name", "cache_shm", {
+                shm_locks = false,
+            })
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+opts.shm_locks must be a string
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: new() ensures opts.shm_locks exists
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local ok, err = mlcache.new("name", "cache_shm", {
+                shm_locks = "foo",
+            })
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+no such lua_shared_dict for opts.shm_locks: foo
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: get() stores resty-locks in opts.shm_locks if specified
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache = assert(mlcache.new("name", "cache_shm", {
+                shm_locks = "locks_shm",
+            }))
+
+            local function cb()
+                local keys = ngx.shared.locks_shm:get_keys()
+                for i, key in ipairs(keys) do
+                    ngx.say(i, ": ", key)
+                end
+
+                return 123
+            end
+
+            cache:get("key", nil, cb)
+        }
+    }
+--- request
+GET /t
+--- response_body
+1: lua-resty-mlcache:lock:namekey
+--- no_error_log
+[error]


### PR DESCRIPTION
Some specific workloads can experience cache churning in their
underlying shm. Creating locks in concurrent mlcache accesses
(from L3 callbacks being triggered) evicts items from the L2 (shm)
cache. When the L3 callback returns no values (miss) that is stored in
the miss shm, that is a shame, since we just purged 30 valid items from
the cache, and accessing those will trigger further L3 callbacks, which
will themselves insert locks, etc...

Even in workloads in which misses are cached in the same shm, this
option still reduces the number of evicted items (since only the
inserted retrieved value will trigger an LRU eviction cycle).