### PR TITLE
Fix expiration when the remaining TTL is exactly 0

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -533,6 +533,13 @@ local function get_shm_set_lru(self, key, shm_key, l1_serializer)
         else
             -- compute elapsed time to get remaining ttl for LRU caching
             remaining_ttl = ttl - (now() - at)
+
+            -- In this case the value is actually expired, but still in the
+            -- shared dict because its expiration is not always accurate.
+            -- Consider the value as stale and fetch a new one.
+            if remaining_ttl <= 0 then
+               return nil, nil, v
+            end
         end
 
         value, err = set_lru(self, key, value, remaining_ttl, remaining_ttl,


### PR DESCRIPTION
As 0 is used as a sentinel for "no TTL" when caching in the worker cache,
if the remaining TTL of a shared hit happens to be exactly 0* that entry
might be cached forever.

This commit fixes that behaviour by considering such cases the same way it
handles a stale value.

* this can happen as the expiration in the shared dict doesn't appear to
  be fully accurate