### PR TITLE
Fix installation directory for bundled IPC

### DIFF
--- a/lua-resty-mlcache-2.2.1-1.rockspec
+++ b/lua-resty-mlcache-2.2.1-1.rockspec
@@ -32,7 +32,7 @@ description = {
 build = {
   type    = "builtin",
   modules = {
-    ["resty.ipc"]     = "lib/resty/mlcache/ipc.lua",
-    ["resty.mlcache"] = "lib/resty/mlcache.lua"
+    ["resty.mlcache.ipc"] = "lib/resty/mlcache/ipc.lua",
+    ["resty.mlcache"]     = "lib/resty/mlcache.lua"
   }
 }


### PR DESCRIPTION
Previously, attempting to use the bundled IPC library via something like defining 'ipc_shm` in the constructor failed.