### PR TITLE
be resilient to table errors

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -765,7 +765,7 @@ function _M:get(key, opts, cb, ...)
 
     local pok, perr, err, new_ttl = xpcall(cb, traceback, ...)
     if not pok then
-        return unlock_and_ret(lock, nil, "callback threw an error: " .. perr)
+        return unlock_and_ret(lock, nil, "callback threw an error: " .. tostring(perr))
     end
 
     if err then

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -765,7 +765,8 @@ function _M:get(key, opts, cb, ...)
 
     local pok, perr, err, new_ttl = xpcall(cb, traceback, ...)
     if not pok then
-        return unlock_and_ret(lock, nil, "callback threw an error: " .. tostring(perr))
+        return unlock_and_ret(lock, nil,
+            "callback threw an error: " .. tostring(perr))
     end
 
     if err then


### PR DESCRIPTION
managed to hit this today, though tostring wouldn't show a useful value for me, it would at least work: ` attempt to concatenate local 'perr' (a table value)`