### PR TITLE
feat: use lrucache.flush_all when available

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -118,13 +118,14 @@ local function rebuild_lru(self)
     local name = self.name
 
     if self.lru then
-        -- When calling purge(), we invalidate the entire LRU by
-        -- GC-ing it.
-        -- lua-resty-lrucache has a 'flush_all()' method in development
-        -- which would be more appropriate:
-        -- https://github.com/openresty/lua-resty-lrucache/pull/23
-        LRU_INSTANCES[name] = nil
-        self.lru = nil
+        if self.lru.flush_all then
+            -- Use 'flush_all' from new versions of lua-resty-lrucache.
+            self.lru:flush_all()
+        else
+            -- Invalidate the entire LRU by GC-ing it.
+            LRU_INSTANCES[name] = nil
+            self.lru = nil
+        end
     end
 
     -- Several mlcache instances can have the same name and hence, the same


### PR DESCRIPTION
Changes `rebuild_lru` to use `lrucache.flush_all()`, allowing custom `lru` implementation to survive `purge()` call.

It works in OpenResty 1.13.6.2 and newer. On older versions uses old behavior.
