### PR TITLE
fix(purge) prevent purging when using a custom LRU cache

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -984,6 +984,10 @@ function _M:purge(flush_expired)
         error("no ipc to propagate purge, specify opts.ipc_shm or opts.ipc", 2)
     end
 
+    if LRU_INSTANCES[self.name] ~= self.lru then
+        error("cannot purge when using custom LRU cache", 2)
+    end
+
     -- clear shm first
     self.dict:flush_all()
 


### PR DESCRIPTION
As it stands, calling `purge()` on an instance that has a custom LRU
cache will also garbage collect said instance, and a new one created by
`lrucache.new()` will take its place.

As long as the new `flush_all()` method for LRU caches isn't supported
(introduced in OpenResty 1.13.6.2), we shall be proactive about this
limitation and prevent the use of `purge()`.

This limitation is soon to be lifted for OpenResty >= 1.13.6.2 thanks
to #78.