### PR TITLE
fix(ipc) avoid replaying all events when spawning new workers

### DIFF
--- a/lib/resty/mlcache/ipc.lua
+++ b/lib/resty/mlcache/ipc.lua
@@ -59,10 +59,19 @@ function _M.new(shm, debug)
         return nil, "no such lua_shared_dict: " .. shm
     end
 
+    local idx, err = dict:get(INDEX_KEY)
+    if err then
+        return nil, "failed to get index: " .. err
+    end
+
+    if idx ~= nil and type(idx) ~= "number" then
+        return nil, "index is not a number, shm tampered with"
+    end
+
     local self    = {
         dict      = dict,
         pid       = debug and 0 or worker_pid(),
-        idx       = 0,
+        idx       = idx or 0,
         callbacks = {},
     }
 


### PR DESCRIPTION
Prior to this fix, new workers spawned to replace existing, long running
ones would attempt to replay all events (from index 0 up to the current
index). This could cause new workers to never catch up with the current
pace of events being broadcast by older workers.

Thanks Robert Paprocki for the report.

Fix #87