### PR TITLE
Support only returning cached values

### DIFF
--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -821,7 +821,7 @@ function _M:get(key, opts, cb, ...)
         error("key must be a string", 2)
     end
 
-    if type(cb) ~= "function" then
+    if type(cb) ~= "function" and (not opts or not opts.cached_only) then
         error("callback must be a function", 2)
     end
 
@@ -864,8 +864,11 @@ function _M:get(key, opts, cb, ...)
     end
 
     -- not in shm either
-    -- single worker must execute the callback
+    if opts and opts.cached_only then
+        return nil, nil, -1
+    end
 
+    -- single worker must execute the callback
     return run_callback(self, key, namespaced_key, data, ttl, neg_ttl,
                         went_stale, l1_serializer, resurrect_ttl,
                         shm_set_tries, cb, ...)

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -821,8 +821,8 @@ function _M:get(key, opts, cb, ...)
         error("key must be a string", 2)
     end
 
-    if cb and type(cb) ~= "function" then
-        error("callback must be a function", 2)
+    if cb ~= nil and type(cb) ~= "function" then
+        error("callback must be nil or a function", 2)
     end
 
     -- worker LRU cache retrieval
@@ -864,7 +864,7 @@ function _M:get(key, opts, cb, ...)
     end
 
     -- not in shm either
-    if not cb then
+    if cb == nil then
         return nil, nil, -1
     end
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -821,7 +821,7 @@ function _M:get(key, opts, cb, ...)
         error("key must be a string", 2)
     end
 
-    if type(cb) ~= "function" and (not opts or not opts.cached_only) then
+    if cb and type(cb) ~= "function" then
         error("callback must be a function", 2)
     end
 
@@ -864,7 +864,7 @@ function _M:get(key, opts, cb, ...)
     end
 
     -- not in shm either
-    if opts and opts.cached_only then
+    if not cb then
         return nil, nil, -1
     end
 

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -85,7 +85,7 @@ key must be a string
                 return
             end
 
-            local ok, err = pcall(cache.get, cache, "key")
+            local ok, err = pcall(cache.get, cache, "key", nil, "not a function")
             if not ok then
                 ngx.say(err)
             end
@@ -2471,7 +2471,9 @@ in negative callback
 --- no_error_log
 [error]
 
-=== TEST 51: get() cached only
+
+
+=== TEST 51: get() nil callback
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2488,7 +2490,7 @@ in negative callback
                 return "hello world"
             end
 
-            local data, err, hit_lvl = cache:get("key", { cached_only = true })
+            local data, err, hit_lvl = cache:get("key")
             if err then
                 ngx.log(ngx.ERR, err)
                 return
@@ -2508,7 +2510,7 @@ in negative callback
 
             -- from lru
 
-            local data, err = cache:get("key", { cached_only = true })
+            local data, err = cache:get("key")
             if err then
                 ngx.log(ngx.ERR, err)
                 return
@@ -2520,7 +2522,7 @@ in negative callback
 
             cache.lru:delete("key")
 
-            local data, err = cache:get("key", { cached_only = true })
+            local data, err = cache:get("key")
             if err then
                 ngx.log(ngx.ERR, err)
                 return

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -89,12 +89,34 @@ key must be a string
             if not ok then
                 ngx.say(err)
             end
+
+            local ok, err = pcall(cache.get, cache, "key", nil, false)
+            if not ok then
+                ngx.say(err)
+            end
+
+            local ok, err = pcall(cache.get, cache, "key", nil, nil)
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("OK")
+            end
+
+            local ok, err = pcall(cache.get, cache, "key", nil, function() return "val" end )
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("OK")
+            end
         }
     }
 --- request
 GET /t
 --- response_body
-callback must be a function
+callback must be nil or a function
+callback must be nil or a function
+OK
+OK
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Adds a new option to `get()` which basically bails before the callback part of a `get()` call.

I have a use case where I never want to touch the slow path. I would rather error or fallback to a default value.
`peek()` works for this, but in the normal case where the value is available in L1 cache, `peek()` goes all the way to L3 and does de-serialisation etc. Super slow unfortunately.

In my case I start up a background timer (with locking so it only runs once across all my workers) that does a [blocking](https://www.consul.io/api-docs/features/blocking) query to Consul.
When the key value changes I `set()` it into mlcache.

At startup the cache is empty but I don't want a pile of requests to try and fetch from Consul, I just want to wait until the background thread has done it's thing with `set()`

Happy to tweak naming or whatever. This was the quickest approach to fixing my `peek()` usage!