### PR TITLE
fix vim tabstop modelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# vim:st=2 sts=2 sw=2 et:
+# vim: ts=2 sts=2 sw=2 et:
 
 os: linux
 dist: xenial

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -1,4 +1,4 @@
--- vim: st=4 sts=4 sw=4 et:
+-- vim: ts=4 sts=4 sw=4 et:
 
 local cjson      = require "cjson.safe"
 local new_tab    = require "table.new"

--- a/lib/resty/mlcache/ipc.lua
+++ b/lib/resty/mlcache/ipc.lua
@@ -1,4 +1,4 @@
--- vim: st=4 sts=4 sw=4 et:
+-- vim: ts=4 sts=4 sw=4 et:
 
 local ERR          = ngx.ERR
 local WARN         = ngx.WARN


### PR DESCRIPTION
I checked out this repo to read through the code locally and was greeted with some errors from vim about the modelines in the files:

![Screenshot from 2021-01-15 07-36-36](https://user-images.githubusercontent.com/3277009/104747478-6e2fa000-5705-11eb-9f58-63a602a67d32.png)

Here's a `s/st=/ts=/` for all the files with the invalid `st` modeline option in them :)