### PR TITLE
Improve documentation for `get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ perform all the work.
 
 _When this method succeeds_, it returns `value`, and `err` is set to `nil`.
 **Because `nil` values from the L3 callback can be cached (i.e. "negative
-caching"), `value` can be nil albeit already cached. Hence, one must note to
+caching"), `value` can be `nil` albeit already cached. Hence, one must note to
 check the second return value `err` to determine if this method succeeded or
 not**.
 

--- a/README.md
+++ b/README.md
@@ -452,8 +452,8 @@ if value == nil then
     elseif err == nil then
         -- negative hit (cached `nil`)
     else
-	    -- error
-	end
+        -- error
+    end
 
 end
 ```

--- a/README.md
+++ b/README.md
@@ -338,17 +338,18 @@ Perform a cache lookup. This is the primary and most efficient method of this
 module. A typical pattern is to *not* call [set()](#set), and let [get()](#get)
 perform all the work.
 
-When this method succeeds, it returns `value` and no error. **Because `nil`
-values from the L3 callback can be cached (i.e. "negative caching"), `value` can
-be nil albeit already cached. Hence, one must rely on the second return value
-`err` to determine if this method succeeded or not**.
+_When this method succeeds_, it returns `value`, and `err` is set to `nil`.
+**Because `nil` values from the L3 callback can be cached (i.e. "negative
+caching"), `value` can be nil albeit already cached. Hence, one must note to
+check the second return value `err` to determine if this method succeeded or
+not**.
 
 The third return value is a number which is set if no error was encountered.
-It indicated the level at which the value was fetched: `1` for L1, `2` for L2,
+It indicates the level at which the value was fetched: `1` for L1, `2` for L2,
 and `3` for L3.
 
-If an error is encountered, this method returns `nil` plus a string describing
-the error.
+_If, however, an error is encountered,_ this method returns `nil` in `value`,
+plus a string describing the error in `err`.
 
 The first argument `key` is a string. Each value must be stored under a unique
 key.
@@ -448,9 +449,12 @@ local value, err, hit_lvl = cache:get("key")
 if value == nil then
     if hit_lvl == -1 then
         -- miss (no value)
-    end
+    elseif err == nil then
+        -- negative hit (cached `nil`)
+    else
+	    -- error
+	end
 
-    -- negative hit (cached `nil`)
 end
 ```
 


### PR DESCRIPTION
I'm hoping that this little bit of a rewrite is much more explicit for somebody who isn't as used to lua yet, and is also more explicit for everybody in terms of what gets returned where. At the very least, this also fixes the demo code for handling return values from `get` (we actually have 3 cases: "miss", "negative hit", and "error").

One interesting thing which I realized: if the callback were to be written following the rules as expected, one would expect that you could also test `hit_level`, and if it were `nil`, that means we got an error? Probably best not to use this logic, I guess? But it's an interesting thought.